### PR TITLE
Update UIElementMixin.java: null-safe string comparison

### DIFF
--- a/src/main/java/com/apothicon/cosmicscreening/mixins/UIElementMixin.java
+++ b/src/main/java/com/apothicon/cosmicscreening/mixins/UIElementMixin.java
@@ -8,6 +8,7 @@ import finalforeach.cosmicreach.gamestates.YouDiedMenu;
 import finalforeach.cosmicreach.lang.Lang;
 import finalforeach.cosmicreach.ui.UIElement;
 import finalforeach.cosmicreach.ui.UIObject;
+import java.util.Objects;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,7 +21,7 @@ public abstract class UIElementMixin implements UIObject {
 
     @Inject(at = @At("HEAD"), method = "onClick")
     public void onClick(CallbackInfo ci) {
-        if (text.equals(Lang.get("Return_to_Main_Menu")) && (GameState.currentGameState instanceof PauseMenu || GameState.currentGameState instanceof YouDiedMenu)) {
+        if (Objects.equals(text, Lang.get("Return_to_Main_Menu")) && (GameState.currentGameState instanceof PauseMenu || GameState.currentGameState instanceof YouDiedMenu)) {
             TickRunner.INSTANCE.continueTickThread();
             GameState.switchToGameState(GameState.IN_GAME);
             CosmicScreening.takeScreenshot = 4;


### PR DESCRIPTION
Fixes crash with mod menu or with any UIElements that have text set to `null`

## Crash Log with Mod Menu

```st
[INFO] [finalforeach.cosmicreach.gamestates.GameState]: Switching to a different gamestate: ModListGameState 
[SEVERE] [java.lang.Throwable]: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "this.text" is null 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.ui.UIElement.handler$zze000$cosmicscreening$onClick(UIElement.java:523) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.ui.UIElement.onClick(UIElement.java) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.modmenu.ui.ModListGameState$4.onClick(ModListGameState.java:160) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.modmenu.ui.ModListGameState.create(ModListGameState.java:174) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.gamestates.GameState.lambda$switchToGameState$0(GameState.java:83) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.Threads.runOnMainThread(Threads.java:16) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.gamestates.GameState.switchToGameState(GameState.java:68) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.modmenu.ui.RenderUtils$1.onClick(RenderUtils.java:28) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.ui.UIElement.drawBackground(UIElement.java:145) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.gamestates.GameState.drawUIElements(GameState.java:121) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.gamestates.MainMenu.render(MainMenu.java:209) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.BlockGame.render(BlockGame.java:132) 
[SEVERE] [java.lang.Throwable]: 	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:387) 
[SEVERE] [java.lang.Throwable]: 	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:193) 
[SEVERE] [java.lang.Throwable]: 	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:167) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.lwjgl3.Lwjgl3Launcher.createApplication(Lwjgl3Launcher.java:104) 
[SEVERE] [java.lang.Throwable]: 	at finalforeach.cosmicreach.lwjgl3.Lwjgl3Launcher.main(Lwjgl3Launcher.java:92) 
[SEVERE] [java.lang.Throwable]: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
[SEVERE] [java.lang.Throwable]: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) 
[SEVERE] [java.lang.Throwable]: 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 
[SEVERE] [java.lang.Throwable]: 	at java.base/java.lang.reflect.Method.invoke(Method.java:568) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.cosmicquilt.loader.CosmicGameProvider.launch(CosmicGameProvider.java:272) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.cosmicquilt.loader.knot.Knot.launch(Knot.java:23) 
[SEVERE] [java.lang.Throwable]: 	at dev.crmodders.cosmicquilt.loader.knot.KnotClient.main(KnotClient.java:7) 
```